### PR TITLE
fix: disable vue compiler hoisting to fix clashing variables when using standard html tags

### DIFF
--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -121,7 +121,12 @@ function generateStoryImport(
     source: template.trim(),
     filename: 'test.vue',
     id: 'test',
-    compilerOptions: { bindingMetadata: resolvedScript?.bindings },
+    compilerOptions: {
+      bindingMetadata: resolvedScript?.bindings,
+      // prevent the hoisting of static variables since that would
+      // result in clashing variable names when the same HTML Tags are used in multiple stories within the same `*.stories.vue` file.
+      hoistStatic: false,
+    },
   })
 
   // Capitalize id to avoid collisions with standard js keywords (e.g. if the id is 'default')

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -400,8 +400,8 @@ describe('transform', () => {
     `)
   })
 
-  it("should prevent hoisting static variables within the same story", async () => {
-     const code = `
+  it('should prevent hoisting static variables within the same story', async () => {
+    const code = `
       <template>
         <Stories>
           <Story title="Primary">
@@ -423,7 +423,7 @@ describe('transform', () => {
 
     const result = await transform(code)
 
-    expect(result.match(/const _hoisted_/g)).toBeNull();
+    expect(result.match(/const _hoisted_/g)).toBeNull()
     expect(result).toMatchInlineSnapshot(`
       "import { defineComponent as _defineComponent } from \\"vue\\";
 


### PR DESCRIPTION
disables the `hoistStatic` property of `vue/compiler-sfc` `compileTemplate` which resulted in clashing `const` variable names being created.

fixes #67 