### PR TITLE
chore: use workspace feature for example

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Commands:
 - `dev`: Build in watch mode.
 - `lint`: Check for eslint and prettier issues.
 - `test`: Run the tests.
-- `example:vite`: Open the example storybook (using vite).
+- `example:vite`: Open the example storybook (using vite). You need to run `build` or `dev` first.
 - `play`: Run the playground (currently not used).
 - `release`: Release a new version to npm.
 

--- a/examples/vite/.storybook/main.ts
+++ b/examples/vite/.storybook/main.ts
@@ -5,7 +5,7 @@ export default {
     '@storybook/addon-links',
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',
-    '../../../src/storybook.ts',
+    'storybook-vue-addon',
   ],
   framework: {
     name: '@storybook/vue3-vite',

--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -18,6 +18,7 @@
     "@storybook/addon-actions": "^7.4.6",
     "@storybook/addon-essentials": "^7.4.6",
     "@storybook/addon-interactions": "^7.4.6",
+    "storybook-vue-addon": "workspace:*",
     "@storybook/addon-links": "^7.4.6",
     "@storybook/jest": "^0.2.3",
     "@storybook/testing-library": "0.2.2",

--- a/examples/vite/src/tests/explicit-types.stories.vue
+++ b/examples/vite/src/tests/explicit-types.stories.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import MyButton from '../components/Button.vue'
-import type { Story, Stories } from '../../../../src/types'
+import type { Story, Stories } from 'storybook-vue-addon/types'
 </script>
 
 <template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
       storybook:
         specifier: 7.4.6
         version: 7.4.6
+      storybook-vue-addon:
+        specifier: workspace:*
+        version: link:../..
       typescript:
         specifier: ~5.2.2
         version: 5.2.2


### PR DESCRIPTION
Fixes #75.

@floroz is this what you had in mind? I don't think we need to move the `src` folder for this since the root is always added as a worskpace. I didn't touch the playground, which is there anyway only for quick local tests.