### PR TITLE
feat: remove prettier dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,8 +97,6 @@
   "dependencies": {
     "@storybook/mdx2-csf": "^1.1.0",
     "consola": "^3.2.3",
-    "prettier": "^3.0.3",
-    "prettier-plugin-organize-imports": "^4.0.0",
     "unplugin": "^3.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,12 +17,6 @@ importers:
       esbuild:
         specifier: '*'
         version: 0.27.7
-      prettier:
-        specifier: ^3.0.3
-        version: 3.8.3
-      prettier-plugin-organize-imports:
-        specifier: ^4.0.0
-        version: 4.3.0(prettier@3.8.3)(typescript@5.9.3)(vue-tsc@3.2.8(typescript@5.9.3))
       unplugin:
         specifier: ^3.0.0
         version: 3.0.0
@@ -2232,16 +2226,6 @@ packages:
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
-
-  prettier-plugin-organize-imports@4.3.0:
-    resolution: {integrity: sha512-FxFz0qFhyBsGdIsb697f/EkvHzi5SZOhWAjxcx2dLt+Q532bAlhswcXGYB1yzjZ69kW8UoadFBw7TyNwlq96Iw==}
-    peerDependencies:
-      prettier: '>=2.0'
-      typescript: '>=2.9'
-      vue-tsc: ^2.1.0 || 3
-    peerDependenciesMeta:
-      vue-tsc:
-        optional: true
 
   prettier@3.8.3:
     resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
@@ -4692,14 +4676,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  prettier-plugin-organize-imports@4.3.0(prettier@3.8.3)(typescript@5.9.3)(vue-tsc@3.2.8(typescript@5.9.3)):
-    dependencies:
-      prettier: 3.8.3
-      typescript: 5.9.3
-    optionalDependencies:
-      vue-tsc: 3.2.8(typescript@5.9.3)
-
-  prettier@3.8.3: {}
+  prettier@3.8.3:
+    optional: true
 
   pretty-format@27.5.1:
     dependencies:

--- a/src/core/transform.spec.ts
+++ b/src/core/transform.spec.ts
@@ -8,16 +8,20 @@ describe('transform', () => {
     expect(result).toMatchInlineSnapshot(`
       "const _sfc_main = {};
       export default {
-        //decorators: [ ... ],
-        parameters: {},
-      };
+          
+          
+          //decorators: [ ... ],
+          parameters: {
+            
+          }
+        }
+        
 
       function renderPrimary(_ctx, _cache) {
-        return "hello";
+        return "hello"
       }
-      export const Primary = () =>
-        Object.assign({ render: renderPrimary }, _sfc_main);
-      Primary.storyName = "Primary";
+      export const Primary = () => Object.assign({render: renderPrimary}, _sfc_main);
+      Primary.storyName = 'Primary';
 
       Primary.parameters = {
         docs: { source: { code: \`hello\` } },
@@ -33,18 +37,20 @@ describe('transform', () => {
     expect(result).toMatchInlineSnapshot(`
       "const _sfc_main = {};
       export default {
-        title: "test",
-
-        //decorators: [ ... ],
-        parameters: {},
-      };
+          title: 'test',
+          
+          //decorators: [ ... ],
+          parameters: {
+            
+          }
+        }
+        
 
       function renderPrimary(_ctx, _cache) {
-        return "hello";
+        return "hello"
       }
-      export const Primary = () =>
-        Object.assign({ render: renderPrimary }, _sfc_main);
-      Primary.storyName = "Primary";
+      export const Primary = () => Object.assign({render: renderPrimary}, _sfc_main);
+      Primary.storyName = 'Primary';
 
       Primary.parameters = {
         docs: { source: { code: \`hello\` } },
@@ -65,20 +71,23 @@ describe('transform', () => {
       '<script>const MyComponent = {}</script><template><Stories :component="MyComponent"><Story title="Primary">hello</Story></Stories></template>'
     const result = await transform(code)
     expect(result).toMatchInlineSnapshot(`
-      "const MyComponent = {};
-      const _sfc_main = {};
+      "const MyComponent = {}
+      const _sfc_main = {}
       export default {
-        component: MyComponent,
-        //decorators: [ ... ],
-        parameters: {},
-      };
+          
+          component: MyComponent,
+          //decorators: [ ... ],
+          parameters: {
+            
+          }
+        }
+        
 
       function renderPrimary(_ctx, _cache, $props, $setup, $data, $options) {
-        return "hello";
+        return "hello"
       }
-      export const Primary = () =>
-        Object.assign({ render: renderPrimary }, _sfc_main);
-      Primary.storyName = "Primary";
+      export const Primary = () => Object.assign({render: renderPrimary}, _sfc_main);
+      Primary.storyName = 'Primary';
 
       Primary.parameters = {
         docs: { source: { code: \`hello\` } },
@@ -94,16 +103,20 @@ describe('transform', () => {
     expect(result).toMatchInlineSnapshot(`
       "const _sfc_main = {};
       export default {
-        //decorators: [ ... ],
-        parameters: {},
-      };
+          
+          
+          //decorators: [ ... ],
+          parameters: {
+            
+          }
+        }
+        
 
       function renderPrimary_story(_ctx, _cache) {
-        return "hello";
+        return "hello"
       }
-      export const Primary_story = () =>
-        Object.assign({ render: renderPrimary_story }, _sfc_main);
-      Primary_story.storyName = "Primary story";
+      export const Primary_story = () => Object.assign({render: renderPrimary_story}, _sfc_main);
+      Primary_story.storyName = 'Primary story';
 
       Primary_story.parameters = {
         docs: { source: { code: \`hello\` } },
@@ -119,16 +132,20 @@ describe('transform', () => {
     expect(result).toMatchInlineSnapshot(`
       "const _sfc_main = {};
       export default {
-        //decorators: [ ... ],
-        parameters: {},
-      };
+          
+          
+          //decorators: [ ... ],
+          parameters: {
+            
+          }
+        }
+        
 
       function renderPrimary(_ctx, _cache) {
-        return "hello";
+        return "hello"
       }
-      export const Primary = () =>
-        Object.assign({ render: renderPrimary }, _sfc_main);
-      Primary.storyName = "Primary";
+      export const Primary = () => Object.assign({render: renderPrimary}, _sfc_main);
+      Primary.storyName = 'Primary';
 
       Primary.parameters = {
         docs: { source: { code: \`hello\` } },
@@ -149,27 +166,31 @@ describe('transform', () => {
     expect(result).toMatchInlineSnapshot(`
       "const _sfc_main = {};
       export default {
-        //decorators: [ ... ],
-        parameters: {},
-      };
+          
+          
+          //decorators: [ ... ],
+          parameters: {
+            
+          }
+        }
+        
 
       function renderPrimary(_ctx, _cache) {
-        return "hello";
+        return "hello"
       }
-      export const Primary = () =>
-        Object.assign({ render: renderPrimary }, _sfc_main);
-      Primary.storyName = "Primary";
+      export const Primary = () => Object.assign({render: renderPrimary}, _sfc_main);
+      Primary.storyName = 'Primary';
 
       Primary.parameters = {
         docs: { source: { code: \`hello\` } },
       };
 
+
       function renderSecondary(_ctx, _cache) {
-        return "world";
+        return "world"
       }
-      export const Secondary = () =>
-        Object.assign({ render: renderSecondary }, _sfc_main);
-      Secondary.storyName = "Secondary";
+      export const Secondary = () => Object.assign({render: renderSecondary}, _sfc_main);
+      Secondary.storyName = 'Secondary';
 
       Secondary.parameters = {
         docs: { source: { code: \`world\` } },
@@ -178,7 +199,7 @@ describe('transform', () => {
     `)
   })
 
-  it('combines helper imports for multiple stories', async () => {
+  it('preserves vue imports for multiple stories', async () => {
     const code = `
       <template>
         <Stories>
@@ -190,37 +211,37 @@ describe('transform', () => {
     expect(result).toMatchInlineSnapshot(`
       "const _sfc_main = {};
       export default {
-        //decorators: [ ... ],
-        parameters: {},
-      };
-
-      import {
-        createBlock as _createBlock,
-        openBlock as _openBlock,
-        resolveComponent as _resolveComponent,
-      } from "vue";
+          
+          
+          //decorators: [ ... ],
+          parameters: {
+            
+          }
+        }
+        
+      import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 
       function renderPrimary(_ctx, _cache) {
-        const _component_Button = _resolveComponent("Button");
+        const _component_Button = _resolveComponent("Button")
 
-        return (_openBlock(), _createBlock(_component_Button));
+        return (_openBlock(), _createBlock(_component_Button))
       }
-      export const Primary = () =>
-        Object.assign({ render: renderPrimary }, _sfc_main);
-      Primary.storyName = "Primary";
+      export const Primary = () => Object.assign({render: renderPrimary}, _sfc_main);
+      Primary.storyName = 'Primary';
 
       Primary.parameters = {
         docs: { source: { code: \`<Button>\` } },
       };
 
-      function renderSecondary(_ctx, _cache) {
-        const _component_Button = _resolveComponent("Button");
+      import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 
-        return (_openBlock(), _createBlock(_component_Button));
+      function renderSecondary(_ctx, _cache) {
+        const _component_Button = _resolveComponent("Button")
+
+        return (_openBlock(), _createBlock(_component_Button))
       }
-      export const Secondary = () =>
-        Object.assign({ render: renderSecondary }, _sfc_main);
-      Secondary.storyName = "Secondary";
+      export const Secondary = () => Object.assign({render: renderSecondary}, _sfc_main);
+      Secondary.storyName = 'Secondary';
 
       Secondary.parameters = {
         docs: { source: { code: \`<Button>\` } },
@@ -246,38 +267,40 @@ describe('transform', () => {
       </template>`
     const result = await transform(code)
     expect(result).toMatchInlineSnapshot(`
-      "const _sfc_main = {
+      "
+      const _sfc_main = {
         setup(__props, { expose: __expose }) {
-          __expose();
+        __expose();
 
-          const test = {
-            data() {
-              return { a: 123 };
-            },
-            template: "<span>{{a}}</span>",
-          };
+            const test = {
+              data() {
+                return { a: 123 }
+              },
+              template: '<span>{{a}}</span>'
+            }
+            
+      const __returned__ = { test }
+      Object.defineProperty(__returned__, '__isScriptSetup', { enumerable: false, value: true })
+      return __returned__
+      }
 
-          const __returned__ = { test };
-          Object.defineProperty(__returned__, "__isScriptSetup", {
-            enumerable: false,
-            value: true,
-          });
-          return __returned__;
-        },
-      };
+      }
       export default {
-        //decorators: [ ... ],
-        parameters: {},
-      };
-
-      import { createBlock as _createBlock, openBlock as _openBlock } from "vue";
+          
+          
+          //decorators: [ ... ],
+          parameters: {
+            
+          }
+        }
+        
+      import { openBlock as _openBlock, createBlock as _createBlock } from "vue"
 
       function renderPrimary(_ctx, _cache, $props, $setup, $data, $options) {
-        return (_openBlock(), _createBlock($setup["test"]));
+        return (_openBlock(), _createBlock($setup["test"]))
       }
-      export const Primary = () =>
-        Object.assign({ render: renderPrimary }, _sfc_main);
-      Primary.storyName = "Primary";
+      export const Primary = () => Object.assign({render: renderPrimary}, _sfc_main);
+      Primary.storyName = 'Primary';
 
       Primary.parameters = {
         docs: { source: { code: \`<test></test>\` } },
@@ -304,64 +327,47 @@ describe('transform', () => {
     expect(result).toMatchInlineSnapshot(`
       "const _sfc_main = {};
       export default {
-        //decorators: [ ... ],
-        parameters: {
-          docs: { page: MDXContent },
-        },
-      };
+          
+          
+          //decorators: [ ... ],
+          parameters: {
+            docs: { page: MDXContent },
+          }
+        }
+        
 
       function renderPrimary(_ctx, _cache) {
-        return "hello";
+        return "hello"
       }
-      export const Primary = () =>
-        Object.assign({ render: renderPrimary }, _sfc_main);
-      Primary.storyName = "Primary";
+      export const Primary = () => Object.assign({render: renderPrimary}, _sfc_main);
+      Primary.storyName = 'Primary';
 
       Primary.parameters = {
         docs: { source: { code: \`hello\` } },
-      }; /*@jsxRuntime automatic @jsxImportSource react*/
-      import { useMDXComponents as _provideComponents } from "@mdx-js/react";
-      import {
-        Fragment as _Fragment,
-        jsx as _jsx,
-        jsxs as _jsxs,
-      } from "react/jsx-runtime";
+      };
+      /*@jsxRuntime automatic @jsxImportSource react*/
+      import {Fragment as _Fragment, jsx as _jsx, jsxs as _jsxs} from "react/jsx-runtime";
+      import {useMDXComponents as _provideComponents} from "@mdx-js/react";
       function _createMdxContent(props) {
-        const _components = Object.assign(
-          {
-            h1: "h1",
-            p: "p",
-          },
-          _provideComponents(),
-          props.components,
-        );
+        const _components = Object.assign({
+          h1: "h1",
+          p: "p"
+        }, _provideComponents(), props.components);
         return _jsxs(_Fragment, {
-          children: [
-            _jsx(_components.h1, {
-              children: "Hello",
-            }),
-            "\\n",
-            _jsx(_components.p, {
-              children: "This is a story",
-            }),
-          ],
+          children: [_jsx(_components.h1, {
+            children: "Hello"
+          }), "\\n", _jsx(_components.p, {
+            children: "This is a story"
+          })]
         });
       }
       function MDXContent(props = {}) {
-        const { wrapper: MDXLayout } = Object.assign(
-          {},
-          _provideComponents(),
-          props.components,
-        );
-        return MDXLayout
-          ? _jsx(
-              MDXLayout,
-              Object.assign({}, props, {
-                children: _jsx(_createMdxContent, props),
-              }),
-            )
-          : _createMdxContent(props);
+        const {wrapper: MDXLayout} = Object.assign({}, _provideComponents(), props.components);
+        return MDXLayout ? _jsx(MDXLayout, Object.assign({}, props, {
+          children: _jsx(_createMdxContent, props)
+        })) : _createMdxContent(props);
       }
+
       "
     `)
   })
@@ -384,22 +390,27 @@ describe('transform', () => {
       `
     const result = await transform(code)
     expect(result).toMatchInlineSnapshot(`
-      "function playFunction({ canvasElement }: any) {
-        console.log("playFunction");
-      }
-
-      const _sfc_main = {};
+      "
+            function playFunction({canvasElement}: any) {
+              console.log("playFunction")
+            }
+            
+      const _sfc_main = {}
       export default {
-        //decorators: [ ... ],
-        parameters: {},
-      };
+          
+          
+          //decorators: [ ... ],
+          parameters: {
+            
+          }
+        }
+        
 
       function renderPrimary(_ctx, _cache, $props, $setup, $data, $options) {
-        return "hello";
+        return "hello"
       }
-      export const Primary = () =>
-        Object.assign({ render: renderPrimary }, _sfc_main);
-      Primary.storyName = "Primary";
+      export const Primary = () => Object.assign({render: renderPrimary}, _sfc_main);
+      Primary.storyName = 'Primary';
       Primary.play = playFunction;
       Primary.parameters = {
         docs: { source: { code: \`hello\` } },
@@ -433,87 +444,60 @@ describe('transform', () => {
 
     expect(result.match(/const _hoisted_/g)).toBeNull()
     expect(result).toMatchInlineSnapshot(`
-      "import { defineComponent as _defineComponent } from "vue";
-      const headingText = "Hello";
-      const paragraph = "World";
-
+      "import { defineComponent as _defineComponent } from 'vue'
+      const headingText = 'Hello';
+              const paragraph = 'World';
+            
       const _sfc_main = _defineComponent({
         setup(__props, { expose: __expose }) {
-          __expose();
+        __expose();
 
-          const __returned__ = { headingText, paragraph };
-          Object.defineProperty(__returned__, "__isScriptSetup", {
-            enumerable: false,
-            value: true,
-          });
-          return __returned__;
-        },
-      });
+              
+      const __returned__ = { headingText, paragraph }
+      Object.defineProperty(__returned__, '__isScriptSetup', { enumerable: false, value: true })
+      return __returned__
+      }
+
+      })
       export default {
-        //decorators: [ ... ],
-        parameters: {},
-      };
-
-      import {
-        createElementBlock as _createElementBlock,
-        createElementVNode as _createElementVNode,
-        Fragment as _Fragment,
-        openBlock as _openBlock,
-        toDisplayString as _toDisplayString,
-      } from "vue";
+          
+          
+          //decorators: [ ... ],
+          parameters: {
+            
+          }
+        }
+        
+      import { toDisplayString as _toDisplayString, createElementVNode as _createElementVNode, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
       function renderPrimary(_ctx, _cache, $props, $setup, $data, $options) {
-        return (
-          _openBlock(),
-          _createElementBlock(
-            _Fragment,
-            null,
-            [
-              _createElementVNode("h1", null, _toDisplayString($setup.headingText)),
-              _createElementVNode("p", null, _toDisplayString($setup.paragraph)),
-            ],
-            64 /* STABLE_FRAGMENT */,
-          )
-        );
+        return (_openBlock(), _createElementBlock(_Fragment, null, [
+          _createElementVNode("h1", null, _toDisplayString($setup.headingText)),
+          _createElementVNode("p", null, _toDisplayString($setup.paragraph))
+        ], 64 /* STABLE_FRAGMENT */))
       }
-      export const Primary = () =>
-        Object.assign({ render: renderPrimary }, _sfc_main);
-      Primary.storyName = "Primary";
+      export const Primary = () => Object.assign({render: renderPrimary}, _sfc_main);
+      Primary.storyName = 'Primary';
 
       Primary.parameters = {
-        docs: {
-          source: {
-            code: \`<h1>{{ headingText }}</h1>
-                  <p>{{ paragraph }}</p>\`,
-          },
-        },
+        docs: { source: { code: \`<h1>{{ headingText }}</h1>
+                  <p>{{ paragraph }}</p>\` } },
       };
 
+      import { toDisplayString as _toDisplayString, createElementVNode as _createElementVNode, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
       function renderSecondary(_ctx, _cache, $props, $setup, $data, $options) {
-        return (
-          _openBlock(),
-          _createElementBlock(
-            _Fragment,
-            null,
-            [
-              _createElementVNode("h1", null, _toDisplayString($setup.headingText)),
-              _createElementVNode("p", null, _toDisplayString($setup.paragraph)),
-            ],
-            64 /* STABLE_FRAGMENT */,
-          )
-        );
+        return (_openBlock(), _createElementBlock(_Fragment, null, [
+          _createElementVNode("h1", null, _toDisplayString($setup.headingText)),
+          _createElementVNode("p", null, _toDisplayString($setup.paragraph))
+        ], 64 /* STABLE_FRAGMENT */))
       }
-      export const Secondary = () =>
-        Object.assign({ render: renderSecondary }, _sfc_main);
-      Secondary.storyName = "Secondary";
+      export const Secondary = () => Object.assign({render: renderSecondary}, _sfc_main);
+      Secondary.storyName = 'Secondary';
 
       Secondary.parameters = {
-        docs: {
-          source: {
-            code: \`<h1>{{ headingText }}</h1>
-                  <p>{{ paragraph }}</p>\`,
-          },
-        },
+        docs: { source: { code: \`<h1>{{ headingText }}</h1>
+                  <p>{{ paragraph }}</p>\` } },
       };
       "
     `)

--- a/src/core/transform.spec.ts
+++ b/src/core/transform.spec.ts
@@ -8,14 +8,13 @@ describe('transform', () => {
     expect(result).toMatchInlineSnapshot(`
       "const _sfc_main = {};
       export default {
-          
-          
+
+
           //decorators: [ ... ],
           parameters: {
-            
+
           }
         }
-        
 
       function renderPrimary(_ctx, _cache) {
         return "hello"
@@ -38,13 +37,12 @@ describe('transform', () => {
       "const _sfc_main = {};
       export default {
           title: 'test',
-          
+
           //decorators: [ ... ],
           parameters: {
-            
+
           }
         }
-        
 
       function renderPrimary(_ctx, _cache) {
         return "hello"
@@ -74,14 +72,13 @@ describe('transform', () => {
       "const MyComponent = {}
       const _sfc_main = {}
       export default {
-          
+
           component: MyComponent,
           //decorators: [ ... ],
           parameters: {
-            
+
           }
         }
-        
 
       function renderPrimary(_ctx, _cache, $props, $setup, $data, $options) {
         return "hello"
@@ -103,14 +100,13 @@ describe('transform', () => {
     expect(result).toMatchInlineSnapshot(`
       "const _sfc_main = {};
       export default {
-          
-          
+
+
           //decorators: [ ... ],
           parameters: {
-            
+
           }
         }
-        
 
       function renderPrimary_story(_ctx, _cache) {
         return "hello"
@@ -132,14 +128,13 @@ describe('transform', () => {
     expect(result).toMatchInlineSnapshot(`
       "const _sfc_main = {};
       export default {
-          
-          
+
+
           //decorators: [ ... ],
           parameters: {
-            
+
           }
         }
-        
 
       function renderPrimary(_ctx, _cache) {
         return "hello"
@@ -166,14 +161,13 @@ describe('transform', () => {
     expect(result).toMatchInlineSnapshot(`
       "const _sfc_main = {};
       export default {
-          
-          
+
+
           //decorators: [ ... ],
           parameters: {
-            
+
           }
         }
-        
 
       function renderPrimary(_ctx, _cache) {
         return "hello"
@@ -184,7 +178,6 @@ describe('transform', () => {
       Primary.parameters = {
         docs: { source: { code: \`hello\` } },
       };
-
 
       function renderSecondary(_ctx, _cache) {
         return "world"
@@ -199,7 +192,7 @@ describe('transform', () => {
     `)
   })
 
-  it('preserves vue imports for multiple stories', async () => {
+  it('consolidates vue imports for multiple stories at the top', async () => {
     const code = `
       <template>
         <Stories>
@@ -211,19 +204,18 @@ describe('transform', () => {
     expect(result).toMatchInlineSnapshot(`
       "const _sfc_main = {};
       export default {
-          
-          
+
+
           //decorators: [ ... ],
           parameters: {
-            
+
           }
         }
-        
-      import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+        import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+
 
       function renderPrimary(_ctx, _cache) {
         const _component_Button = _resolveComponent("Button")
-
         return (_openBlock(), _createBlock(_component_Button))
       }
       export const Primary = () => Object.assign({render: renderPrimary}, _sfc_main);
@@ -233,11 +225,8 @@ describe('transform', () => {
         docs: { source: { code: \`<Button>\` } },
       };
 
-      import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
-
       function renderSecondary(_ctx, _cache) {
         const _component_Button = _resolveComponent("Button")
-
         return (_openBlock(), _createBlock(_component_Button))
       }
       export const Secondary = () => Object.assign({render: renderSecondary}, _sfc_main);
@@ -278,7 +267,7 @@ describe('transform', () => {
               },
               template: '<span>{{a}}</span>'
             }
-            
+
       const __returned__ = { test }
       Object.defineProperty(__returned__, '__isScriptSetup', { enumerable: false, value: true })
       return __returned__
@@ -286,15 +275,15 @@ describe('transform', () => {
 
       }
       export default {
-          
-          
+
+
           //decorators: [ ... ],
           parameters: {
-            
+
           }
         }
-        
-      import { openBlock as _openBlock, createBlock as _createBlock } from "vue"
+        import { openBlock as _openBlock, createBlock as _createBlock } from "vue"
+
 
       function renderPrimary(_ctx, _cache, $props, $setup, $data, $options) {
         return (_openBlock(), _createBlock($setup["test"]))
@@ -327,14 +316,13 @@ describe('transform', () => {
     expect(result).toMatchInlineSnapshot(`
       "const _sfc_main = {};
       export default {
-          
-          
+
+
           //decorators: [ ... ],
           parameters: {
             docs: { page: MDXContent },
           }
         }
-        
 
       function renderPrimary(_ctx, _cache) {
         return "hello"
@@ -394,17 +382,16 @@ describe('transform', () => {
             function playFunction({canvasElement}: any) {
               console.log("playFunction")
             }
-            
+
       const _sfc_main = {}
       export default {
-          
-          
+
+
           //decorators: [ ... ],
           parameters: {
-            
+
           }
         }
-        
 
       function renderPrimary(_ctx, _cache, $props, $setup, $data, $options) {
         return "hello"
@@ -447,12 +434,12 @@ describe('transform', () => {
       "import { defineComponent as _defineComponent } from 'vue'
       const headingText = 'Hello';
               const paragraph = 'World';
-            
+
       const _sfc_main = _defineComponent({
         setup(__props, { expose: __expose }) {
         __expose();
 
-              
+
       const __returned__ = { headingText, paragraph }
       Object.defineProperty(__returned__, '__isScriptSetup', { enumerable: false, value: true })
       return __returned__
@@ -460,15 +447,15 @@ describe('transform', () => {
 
       })
       export default {
-          
-          
+
+
           //decorators: [ ... ],
           parameters: {
-            
+
           }
         }
-        
-      import { toDisplayString as _toDisplayString, createElementVNode as _createElementVNode, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+        import { toDisplayString as _toDisplayString, createElementVNode as _createElementVNode, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
 
       function renderPrimary(_ctx, _cache, $props, $setup, $data, $options) {
         return (_openBlock(), _createElementBlock(_Fragment, null, [
@@ -483,8 +470,6 @@ describe('transform', () => {
         docs: { source: { code: \`<h1>{{ headingText }}</h1>
                   <p>{{ paragraph }}</p>\` } },
       };
-
-      import { toDisplayString as _toDisplayString, createElementVNode as _createElementVNode, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
       function renderSecondary(_ctx, _cache, $props, $setup, $data, $options) {
         return (_openBlock(), _createElementBlock(_Fragment, null, [

--- a/src/core/transform.spec.ts
+++ b/src/core/transform.spec.ts
@@ -298,6 +298,28 @@ describe('transform', () => {
     `)
   })
 
+  it('strips type-only imports from script setup output', async () => {
+    const code = `
+      <script lang="ts" setup>
+      import MyButton from '../components/Button.vue'
+      import type { Stories, Story } from 'storybook-vue-addon/core'
+      </script>
+
+      <template>
+        <Stories :component="MyButton" title="Tests/Explicit types">
+          <Story title="Default">
+            <MyButton label="Button" />
+          </Story>
+        </Stories>
+      </template>
+      `
+
+    const result = await transform(code)
+
+    expect(result).not.toContain('import type')
+    expect(result).toContain("import MyButton from '../components/Button.vue'")
+  })
+
   it('supports docs blocks', async () => {
     const code = `
       <template>

--- a/src/core/transform.spec.ts
+++ b/src/core/transform.spec.ts
@@ -15,7 +15,7 @@ describe('transform', () => {
             
           }
         }
-        
+
       function renderPrimary(_ctx, _cache) {
         return "hello"
       }
@@ -43,7 +43,7 @@ describe('transform', () => {
             
           }
         }
-        
+
       function renderPrimary(_ctx, _cache) {
         return "hello"
       }
@@ -79,7 +79,7 @@ describe('transform', () => {
             
           }
         }
-        
+
       function renderPrimary(_ctx, _cache, $props, $setup, $data, $options) {
         return "hello"
       }
@@ -107,7 +107,7 @@ describe('transform', () => {
             
           }
         }
-        
+
       function renderPrimary_story(_ctx, _cache) {
         return "hello"
       }
@@ -135,7 +135,7 @@ describe('transform', () => {
             
           }
         }
-        
+
       function renderPrimary(_ctx, _cache) {
         return "hello"
       }
@@ -168,7 +168,7 @@ describe('transform', () => {
             
           }
         }
-        
+
       function renderPrimary(_ctx, _cache) {
         return "hello"
       }
@@ -211,7 +211,7 @@ describe('transform', () => {
             
           }
         }
-        import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+      import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 
 
       function renderPrimary(_ctx, _cache) {
@@ -282,7 +282,7 @@ describe('transform', () => {
             
           }
         }
-        import { openBlock as _openBlock, createBlock as _createBlock } from "vue"
+      import { openBlock as _openBlock, createBlock as _createBlock } from "vue"
 
 
       function renderPrimary(_ctx, _cache, $props, $setup, $data, $options) {
@@ -345,7 +345,7 @@ describe('transform', () => {
             docs: { page: MDXContent },
           }
         }
-        
+
       function renderPrimary(_ctx, _cache) {
         return "hello"
       }
@@ -414,7 +414,7 @@ describe('transform', () => {
             
           }
         }
-        
+
       function renderPrimary(_ctx, _cache, $props, $setup, $data, $options) {
         return "hello"
       }
@@ -476,7 +476,7 @@ describe('transform', () => {
             
           }
         }
-        import { toDisplayString as _toDisplayString, createElementVNode as _createElementVNode, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+      import { toDisplayString as _toDisplayString, createElementVNode as _createElementVNode, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
 
       function renderPrimary(_ctx, _cache, $props, $setup, $data, $options) {

--- a/src/core/transform.spec.ts
+++ b/src/core/transform.spec.ts
@@ -8,14 +8,14 @@ describe('transform', () => {
     expect(result).toMatchInlineSnapshot(`
       "const _sfc_main = {};
       export default {
-
-
+          
+          
           //decorators: [ ... ],
           parameters: {
-
+            
           }
         }
-
+        
       function renderPrimary(_ctx, _cache) {
         return "hello"
       }
@@ -37,13 +37,13 @@ describe('transform', () => {
       "const _sfc_main = {};
       export default {
           title: 'test',
-
+          
           //decorators: [ ... ],
           parameters: {
-
+            
           }
         }
-
+        
       function renderPrimary(_ctx, _cache) {
         return "hello"
       }
@@ -72,14 +72,14 @@ describe('transform', () => {
       "const MyComponent = {}
       const _sfc_main = {}
       export default {
-
+          
           component: MyComponent,
           //decorators: [ ... ],
           parameters: {
-
+            
           }
         }
-
+        
       function renderPrimary(_ctx, _cache, $props, $setup, $data, $options) {
         return "hello"
       }
@@ -100,14 +100,14 @@ describe('transform', () => {
     expect(result).toMatchInlineSnapshot(`
       "const _sfc_main = {};
       export default {
-
-
+          
+          
           //decorators: [ ... ],
           parameters: {
-
+            
           }
         }
-
+        
       function renderPrimary_story(_ctx, _cache) {
         return "hello"
       }
@@ -128,14 +128,14 @@ describe('transform', () => {
     expect(result).toMatchInlineSnapshot(`
       "const _sfc_main = {};
       export default {
-
-
+          
+          
           //decorators: [ ... ],
           parameters: {
-
+            
           }
         }
-
+        
       function renderPrimary(_ctx, _cache) {
         return "hello"
       }
@@ -161,14 +161,14 @@ describe('transform', () => {
     expect(result).toMatchInlineSnapshot(`
       "const _sfc_main = {};
       export default {
-
-
+          
+          
           //decorators: [ ... ],
           parameters: {
-
+            
           }
         }
-
+        
       function renderPrimary(_ctx, _cache) {
         return "hello"
       }
@@ -204,11 +204,11 @@ describe('transform', () => {
     expect(result).toMatchInlineSnapshot(`
       "const _sfc_main = {};
       export default {
-
-
+          
+          
           //decorators: [ ... ],
           parameters: {
-
+            
           }
         }
         import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
@@ -267,7 +267,7 @@ describe('transform', () => {
               },
               template: '<span>{{a}}</span>'
             }
-
+            
       const __returned__ = { test }
       Object.defineProperty(__returned__, '__isScriptSetup', { enumerable: false, value: true })
       return __returned__
@@ -275,11 +275,11 @@ describe('transform', () => {
 
       }
       export default {
-
-
+          
+          
           //decorators: [ ... ],
           parameters: {
-
+            
           }
         }
         import { openBlock as _openBlock, createBlock as _createBlock } from "vue"
@@ -316,14 +316,14 @@ describe('transform', () => {
     expect(result).toMatchInlineSnapshot(`
       "const _sfc_main = {};
       export default {
-
-
+          
+          
           //decorators: [ ... ],
           parameters: {
             docs: { page: MDXContent },
           }
         }
-
+        
       function renderPrimary(_ctx, _cache) {
         return "hello"
       }
@@ -382,17 +382,17 @@ describe('transform', () => {
             function playFunction({canvasElement}: any) {
               console.log("playFunction")
             }
-
+            
       const _sfc_main = {}
       export default {
-
-
+          
+          
           //decorators: [ ... ],
           parameters: {
-
+            
           }
         }
-
+        
       function renderPrimary(_ctx, _cache, $props, $setup, $data, $options) {
         return "hello"
       }
@@ -434,12 +434,12 @@ describe('transform', () => {
       "import { defineComponent as _defineComponent } from 'vue'
       const headingText = 'Hello';
               const paragraph = 'World';
-
+            
       const _sfc_main = _defineComponent({
         setup(__props, { expose: __expose }) {
         __expose();
 
-
+              
       const __returned__ = { headingText, paragraph }
       Object.defineProperty(__returned__, '__isScriptSetup', { enumerable: false, value: true })
       return __returned__
@@ -447,11 +447,11 @@ describe('transform', () => {
 
       })
       export default {
-
-
+          
+          
           //decorators: [ ... ],
           parameters: {
-
+            
           }
         }
         import { toDisplayString as _toDisplayString, createElementVNode as _createElementVNode, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -85,9 +85,24 @@ async function transformTemplate(
   resolvedScript?: SFCScriptBlock,
 ) {
   let result = generateDefaultImport(meta, docs)
+
+  // Collect all imports and story code separately
+  const imports = new Set<string>()
+  let storyCode = ''
+
   for (const story of stories) {
-    result += generateStoryImport(story, resolvedScript)
+    const { code, storyImports } = generateStoryImport(story, resolvedScript)
+    storyImports.forEach(imp => imports.add(imp))
+    storyCode += code
   }
+
+  // Add all collected imports at the top
+  if (imports.size > 0) {
+    result += Array.from(imports).join('\n') + '\n\n'
+  }
+
+  result += storyCode
+
   if (docs) {
     let mdx = await compileMdx(docs, { skipCsf: true })
     mdx = mdx.replace('export default MDXContent;', '')
@@ -111,11 +126,11 @@ function generateDefaultImport({ title, component }: ParsedMeta, docs?: string) 
 function generateStoryImport(
   { id, title, play, template }: ParsedStory,
   resolvedScript?: SFCScriptBlock,
-) {
+): { code: string; storyImports: string[] } {
   const { code } = compileTemplate({
     compilerOptions: {
       bindingMetadata: resolvedScript?.bindings,
-      // prevent the hoisting of static variables since that would
+      // Prevent the hoisting of static variables since that would
       // result in clashing variable names when the same HTML Tags are used in multiple stories within the same `*.stories.vue` file.
       hoistStatic: false,
     },
@@ -124,13 +139,26 @@ function generateStoryImport(
     source: template.trim(),
   })
 
+  // Extract import statements from the compiled code
+  const importRegex = /^import\s+.*?["'][^"']*["'];?$/gm
+  const imports: string[] = []
+  let codeWithoutImports = code
+
+  let match
+  while ((match = importRegex.exec(code)) !== null) {
+    imports.push(match[0])
+  }
+
+  // Remove all import statements from the code
+  codeWithoutImports = code.replace(importRegex, '').replace(/^\s*\n/gm, '')
+
   // Capitalize id to avoid collisions with standard js keywords (e.g. if the id is 'default')
   id = id.charAt(0).toUpperCase() + id.slice(1)
 
-  const renderFunction = code.replace('export function render', `function render${id}`)
+  const renderFunction = codeWithoutImports.replace('export function render', `function render${id}`)
 
   // Each named export is a story, has to return a Vue ComponentOptionsBase
-  return `
+  const storyCode = `
 ${renderFunction}
 export const ${id} = () => Object.assign({render: render${id}}, _sfc_main);
 ${id}.storyName = '${title}';
@@ -139,6 +167,8 @@ ${id}.parameters = {
   docs: { source: { code: \`${template.trim()}\` } },
 };
 `
+
+  return { code: storyCode, storyImports: imports }
 }
 
 

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -92,7 +92,7 @@ async function transformTemplate(
 
   for (const story of stories) {
     const { code, storyImports } = generateStoryImport(story, resolvedScript)
-    storyImports.forEach(imp => imports.add(imp))
+    storyImports.forEach((imp) => imports.add(imp))
     storyCode += code
   }
 
@@ -155,7 +155,10 @@ function generateStoryImport(
   // Capitalize id to avoid collisions with standard js keywords (e.g. if the id is 'default')
   id = id.charAt(0).toUpperCase() + id.slice(1)
 
-  const renderFunction = codeWithoutImports.replace('export function render', `function render${id}`)
+  const renderFunction = codeWithoutImports.replace(
+    'export function render',
+    `function render${id}`,
+  )
 
   // Each named export is a story, has to return a Vue ComponentOptionsBase
   const storyCode = `
@@ -170,5 +173,3 @@ ${id}.parameters = {
 
   return { code: storyCode, storyImports: imports }
 }
-
-

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -14,7 +14,10 @@ export async function transform(code: string) {
   const isTS = resolvedScript?.lang === 'ts'
   if (resolvedScript) {
     const babelPlugins: ParserPlugin[] = isTS ? ['typescript'] : []
-    result += rewriteDefault(resolvedScript.content, '_sfc_main', babelPlugins)
+    const sanitizedScriptContent = isTS
+      ? stripTypeOnlyDeclarations(resolvedScript.content)
+      : resolvedScript.content
+    result += rewriteDefault(sanitizedScriptContent, '_sfc_main', babelPlugins)
     result += '\n'
   } else {
     result += 'const _sfc_main = {};\n'
@@ -172,4 +175,11 @@ ${id}.parameters = {
 `
 
   return { code: storyCode, storyImports: imports }
+}
+
+function stripTypeOnlyDeclarations(scriptContent: string): string {
+  // Type-only declarations are not valid in plain JavaScript output.
+  return scriptContent
+    .replace(/^\s*import\s+type\s+[\s\S]*?from\s+['"][^'"]+['"]\s*;?\s*$/gm, '')
+    .replace(/^\s*export\s+type\s+[\s\S]*?;?\s*$/gm, '')
 }

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -1,6 +1,5 @@
 import type { ParserPlugin } from '@babel/parser'
 import { compile as compileMdx } from '@storybook/mdx2-csf'
-import { format as prettierFormat } from 'prettier'
 import type { SFCScriptBlock } from 'vue/compiler-sfc'
 import { compileTemplate, rewriteDefault } from 'vue/compiler-sfc'
 import type { ParsedMeta, ParsedStory } from './parser'
@@ -18,10 +17,9 @@ export async function transform(code: string) {
     result += rewriteDefault(resolvedScript.content, '_sfc_main', babelPlugins)
     result += '\n'
   } else {
-    result += 'const _sfc_main = {}\n'
+    result += 'const _sfc_main = {};\n'
   }
   result += await transformTemplate({ docs, meta, stories }, resolvedScript)
-  result = await organizeImports(result, isTS)
   return result
 
   /*
@@ -133,19 +131,14 @@ function generateStoryImport(
 
   // Each named export is a story, has to return a Vue ComponentOptionsBase
   return `
-    ${renderFunction}
-    export const ${id} = () => Object.assign({render: render${id}}, _sfc_main)
-    ${id}.storyName = '${title}'
-    ${play ? `${id}.play = ${play}` : ''}
-    ${id}.parameters = {
-      docs: { source: { code: \`${template.trim()}\` } },
-    };`
+${renderFunction}
+export const ${id} = () => Object.assign({render: render${id}}, _sfc_main);
+${id}.storyName = '${title}';
+${play ? `${id}.play = ${play};` : ''}
+${id}.parameters = {
+  docs: { source: { code: \`${template.trim()}\` } },
+};
+`
 }
 
-async function organizeImports(result: string, isTS: boolean): Promise<string> {
-  // Use prettier to organize imports
-  return await prettierFormat(result, {
-    parser: isTS ? 'typescript' : 'babel',
-    plugins: ['prettier-plugin-organize-imports'],
-  })
-}
+

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -122,7 +122,7 @@ function generateDefaultImport({ title, component }: ParsedMeta, docs?: string) 
     parameters: {
       ${docs ? `docs: { page: MDXContent },` : ''}
     }
-  }` + '\n'
+  }\n`
 }
 
 function generateStoryImport(

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -122,8 +122,7 @@ function generateDefaultImport({ title, component }: ParsedMeta, docs?: string) 
     parameters: {
       ${docs ? `docs: { page: MDXContent },` : ''}
     }
-  }
-  `
+  }` + '\n'
 }
 
 function generateStoryImport(


### PR DESCRIPTION
The generated code is consumed by a bundler, not displayed to users. Import order and duplicates should have no effect on functionality as bundlers and ESM runtimes handle module deduplication automatically.